### PR TITLE
Fix overflow bug

### DIFF
--- a/cpp-src/FDBG.cpp
+++ b/cpp-src/FDBG.cpp
@@ -507,17 +507,17 @@ class INorOUT {
 	}
   
     // Set row, col value
-    void set(unsigned row, unsigned col, bool val) {
+    void set(u_int64_t row, u_int64_t col, bool val) {
 
 		  if (row < this->n_orig) {
 			  // original node
 
-        		unsigned index = 4*row + col;
+        		u_int64_t index = 4*row + col;
         		this->bitarray.set(index, val);
 			}
 			else {
 				// added node
-				unsigned index = row - this->n_orig;
+				u_int64_t index = row - this->n_orig;
 				assert(this->added_rows.size() > index);
 				assert(this->added_rows[index].size() > col);
 
@@ -527,15 +527,15 @@ class INorOUT {
     }
 
     // Get row, col value
-    bool get(unsigned row, unsigned col) {
+    bool get(u_int64_t row, u_int64_t col) {
 
 		  if (row < this->n_orig) {
 			  // original node
-	        unsigned index = 4*row + col;
+	        u_int64_t index = 4*row + col;
    	     return this->bitarray.get(index);
 		  }
 		  else {
-				unsigned index = row - this->n_orig;
+				u_int64_t index = row - this->n_orig;
 				assert(this->added_rows.size() > index);
 				assert(this->added_rows[index].size() > col);
 		


### PR DESCRIPTION
There is a bug that causes the program to segfault when the number of k-mers is larger than 2^30. It is caused by an overflow in constructing matrices IN and OUT. This patch fixes this.